### PR TITLE
Ability to ignore middlewares

### DIFF
--- a/lib/rack/freeze/builder.rb
+++ b/lib/rack/freeze/builder.rb
@@ -1,15 +1,15 @@
 # Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,19 +22,34 @@ require 'rack/builder'
 require_relative 'freezer'
 
 module Rack
-	module Freeze
-		module Builder
-			def use(klass, *args, &block)
-				super Freezer.new(klass), *args, &block
-			end
-			
-			def run(app)
-				super app.freeze
-			end
-			
-			def to_app
-				super.freeze
-			end
-		end
-	end
+  module Freeze
+    module Builder
+      def use(klass, *args, &block)
+        if ignored_middleware?(klass)
+          super(klass, *args, &block)
+        else
+          super(Freezer.new(klass), *args, &block)
+        end
+      end
+
+      def run(app)
+        if ignored_middleware?(app.class)
+          super(app)
+        else
+          super(app.freeze)
+        end
+      end
+
+      def to_app
+        app = super
+        ignored_middleware?(app.class) ? app : app.freeze
+      end
+
+      private
+
+      def ignored_middleware?(klass)
+        Rack::Freeze.configuration.ignored_middlewares.include?(klass)
+      end
+    end
+  end
 end

--- a/lib/rack/freeze/configuration.rb
+++ b/lib/rack/freeze/configuration.rb
@@ -1,4 +1,4 @@
-# Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
+# Copyright, 2019, by Klaxit <http://www.klaxit.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -18,21 +18,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-require_relative 'freeze/version'
-require_relative 'freeze/configuration'
-require_relative 'freeze/builder'
-
 module Rack
   module Freeze
-    def self.configure
-      yield(configuration)
-    end
+    class Configuration
+      attr_accessor :ignored_middlewares
 
-    def self.configuration
-      @configuration ||= Rack::Freeze::Configuration.new
+      def initialize
+        @ignored_middlewares = []
+      end
     end
   end
 end
-
-# Enforce the policy globally.
-Rack::Builder.prepend(Rack::Freeze::Builder)

--- a/spec/rack/freeze/builder.rb
+++ b/spec/rack/freeze/builder.rb
@@ -2,34 +2,41 @@
 RSpec.shared_examples_for "frozen middleware" do
 	it "should be entirely frozen" do
 		current = builder.to_app
-		
+
 		expect(current).to_not be_nil
-		
+
 		# This can't traverse into Rack::URLMap and I'm not really sure how it should do that.
 		while current
 			expect(current).to be_frozen
-			
+
 			current = current.respond_to?(:app) ? current.app : nil
 		end
 	end
+
+  it "should not be frozen if configuration ignores it" do
+    allow(Rack::Freeze.configuration).to receive(:ignored_middlewares)
+                                           .and_return([described_class])
+
+    expect(builder.to_app).to_not be_frozen
+  end
 end
 
 RSpec.shared_context "middleware builder" do
 	let(:env) {Hash.new}
-	
+
 	let(:builder) do
 		Rack::Builder.new.tap do |builder|
 			builder.use described_class
 			builder.run lambda { |env| [404, {}, []] }
 		end
 	end
-	
+
 	let(:app) {builder.to_app}
-	
+
 	it "should generate a valid app" do
 		expect(app).to_not be_nil
 	end
-	
+
 	it_behaves_like "frozen middleware"
 end
 
@@ -37,13 +44,13 @@ class FaultyMiddleware
 	def initialize(app)
 		@app = app
 	end
-	
+
 	attr :app
-	
+
 	# Broken implementation of freeze doesn't call @app.freeze
 	def freeze
 		return self if frozen?
-		
+
 		super
 	end
 end
@@ -52,15 +59,15 @@ class GoodMiddleware
 	def initialize(app)
 		@app = app
 	end
-	
+
 	attr :app
-	
+
 	# Broken implementation of freeze doesn't call @app.freeze
 	def freeze
 		return self if frozen?
-		
+
 		@app.freeze
-		
+
 		super
 	end
 end
@@ -70,13 +77,13 @@ class StatefulMiddleware
 		@app = app
 		@state = 0
 	end
-	
+
 	attr :app
 	attr :state
-	
+
 	def call(env)
 		@state += 1
-		
+
 		return @app.call(env)
 	end
 end

--- a/spec/rack/freeze/builder_spec.rb
+++ b/spec/rack/freeze/builder_spec.rb
@@ -2,47 +2,58 @@
 require_relative 'builder'
 
 RSpec.describe StatefulMiddleware do
-	include_context "middleware builder"
-	
-	it "should fail when invoked" do
-		expect{app.call(env)}.to raise_error(RuntimeError, /can't modify frozen/)
-	end
+  include_context "middleware builder"
+
+  it "should fail when invoked" do
+    expect{app.call(env)}.to raise_error(RuntimeError, /can't modify frozen/)
+  end
 end
 
 RSpec.describe GoodMiddleware do
-	include_context "middleware builder"
+  include_context "middleware builder"
 end
 
 RSpec.describe FaultyMiddleware do
-	let(:builder) do
-		Rack::Builder.new do
-			use FaultyMiddleware
-			use GoodMiddleware
-			
-			run proc{}
-		end
-	end
-	
-	it_behaves_like "frozen middleware"
+  let(:builder) do
+    Rack::Builder.new do
+      use FaultyMiddleware
+      use GoodMiddleware
+
+      run proc{}
+    end
+  end
+
+  it_behaves_like "frozen middleware"
 end
 
 require 'rack/urlmap'
 
 RSpec.describe 'Builder#generate_map' do
-	let(:builder) do
-		Rack::Builder.new do
-			map '/foo' do
-				use GoodMiddleware
-				run proc{}
-			end
-			
-			map '/bar' do
-				use FaultyMiddleware
-				use GoodMiddleware
-				run proc{}
-			end
-		end
-	end
-	
-	it_behaves_like "frozen middleware"
+  let(:builder) do
+    Rack::Builder.new do
+      map '/foo' do
+        use GoodMiddleware
+        run proc{}
+      end
+
+      map '/bar' do
+        use FaultyMiddleware
+        use GoodMiddleware
+        run proc{}
+      end
+    end
+  end
+
+  it "should be entirely frozen" do
+    current = builder.to_app
+
+    expect(current).to_not be_nil
+
+    # This can't traverse into Rack::URLMap and I'm not really sure how it should do that.
+    while current
+      expect(current).to be_frozen
+
+      current = current.respond_to?(:app) ? current.app : nil
+    end
+  end
 end


### PR DESCRIPTION
Currently, `rack-freeze` cannot be integrated in any project with one mutable Rack middleware.

In some cases, implementation seem problematic and should be fixed (see my PR on `omniauth`, https://github.com/omniauth/omniauth/pull/983) but in other cases, even some standard and apparently not problematic middlewares cannot be frozen (see [`Rack::Protection::FrameOptions`](https://github.com/sinatra/sinatra/blob/master/rack-protection/lib/rack/protection/frame_options.rb)).

The ability to ignore some middlewares allow the developer to decide wether or not the given middleware should a concern. In my case, it will allow me to integrate `rack-freeze` in a project that really needs it, with the added security it provides, without having to open pull requests on projects that don't really need it.